### PR TITLE
fix(openclaw): simplify fallback agents and allow legacy archived path

### DIFF
--- a/src/routes/openclaw.js
+++ b/src/routes/openclaw.js
@@ -84,6 +84,13 @@ function isAllowedWorkspacePath(workspacePath) {
   // Allow skills directory (moved from /shared/skills to /skills)
   if (workspacePath.startsWith('/skills/') || workspacePath === '/skills') return true;
 
+  // Allow legacy archived workspace path when present
+  if (
+    workspacePath === '/_archived_workspace_main' ||
+    workspacePath.startsWith('/_archived_workspace_main/')
+  )
+    return true;
+
   // Allow agent workspaces
   if (workspacePath.startsWith('/workspace/') || workspacePath === '/workspace') return true;
   if (workspacePath.startsWith('/workspace-') || /^\/workspace-[a-z]+(\/|$)/.test(workspacePath))


### PR DESCRIPTION
Remove the hardcoded archived fallback agent for fresh installs and extend workspace path allowlisting to permit /_archived_workspace_main when it is intentionally present.